### PR TITLE
Add webhook delivery validation

### DIFF
--- a/src-docs/app.py.md
+++ b/src-docs/app.py.md
@@ -5,10 +5,14 @@
 # <kbd>module</kbd> `app.py`
 Flask application which receives GitHub webhooks and logs those. 
 
+**Global Variables**
+---------------
+- **WEBHOOK_SIGNATURE_HEADER**
+- **webhook_secret**
 
 ---
 
-<a href="../src/app.py#L22"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/app.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `setup_logger`
 
@@ -27,7 +31,33 @@ Set up the webhook logger to log to a file.
 
 ---
 
-<a href="../src/app.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/app.py#L60"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `signature_validator`
+
+```python
+signature_validator(
+    func: Callable[[], tuple[str, int]]
+) → Callable[[], tuple[str, int]]
+```
+
+Validate the signature of the incoming request. 
+
+
+
+**Args:**
+ 
+ - <b>`func`</b>:  function to be decorated. 
+
+
+
+**Returns:**
+ Decorated function. 
+
+
+---
+
+<a href="../src/app.py#L93"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `handle_github_webhook`
 

--- a/src-docs/app.py.md
+++ b/src-docs/app.py.md
@@ -12,7 +12,7 @@ Flask application which receives GitHub webhooks and logs those.
 
 ---
 
-<a href="../src/app.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/app.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `setup_logger`
 
@@ -31,7 +31,7 @@ Set up the webhook logger to log to a file.
 
 ---
 
-<a href="../src/app.py#L60"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/app.py#L58"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `signature_validator`
 
@@ -57,7 +57,7 @@ Validate the signature of the incoming request.
 
 ---
 
-<a href="../src/app.py#L93"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/app.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `handle_github_webhook`
 

--- a/src-docs/app.py.md
+++ b/src-docs/app.py.md
@@ -12,7 +12,7 @@ Flask application which receives GitHub webhooks and logs those.
 
 ---
 
-<a href="../src/app.py#L30"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/app.py#L27"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `setup_logger`
 
@@ -31,33 +31,7 @@ Set up the webhook logger to log to a file.
 
 ---
 
-<a href="../src/app.py#L58"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-## <kbd>function</kbd> `signature_validator`
-
-```python
-signature_validator(
-    func: Callable[[], tuple[str, int]]
-) → Callable[[], tuple[str, int]]
-```
-
-Validate the signature of the incoming request. 
-
-
-
-**Args:**
- 
- - <b>`func`</b>:  function to be decorated. 
-
-
-
-**Returns:**
- Decorated function. 
-
-
----
-
-<a href="../src/app.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/app.py#L55"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `handle_github_webhook`
 

--- a/src-docs/validation.py.md
+++ b/src-docs/validation.py.md
@@ -1,0 +1,50 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/validation.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `validation.py`
+Module for validating the webhook request. 
+
+
+---
+
+<a href="../src/validation.py#L14"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `verify_signature`
+
+```python
+verify_signature(
+    payload: bytes,
+    secret_token: str,
+    signature_header: str
+) → None
+```
+
+Verify that the payload was sent from GitHub by validating SHA256. 
+
+Raise error if the signature doesn't match. 
+
+
+
+**Args:**
+ 
+ - <b>`payload`</b>:  original request body to verify (request.body()) 
+ - <b>`secret_token`</b>:  GitHub app webhook token (WEBHOOK_SECRET) 
+ - <b>`signature_header`</b>:  header received from GitHub (x-hub-signature-256) 
+
+
+
+**Raises:**
+ 
+ - <b>`SignatureValidationError`</b>:  if the signature doesn't match 
+
+
+---
+
+## <kbd>class</kbd> `SignatureValidationError`
+Raised when the signature validation fails. 
+
+
+
+
+

--- a/src-docs/validation.py.md
+++ b/src-docs/validation.py.md
@@ -17,7 +17,7 @@ verify_signature(
     payload: bytes,
     secret_token: str,
     signature_header: str
-) → None
+) → bool
 ```
 
 Verify that the payload was sent from GitHub by validating SHA256. 
@@ -34,9 +34,8 @@ Raise error if the signature doesn't match.
 
 
 
-**Raises:**
- 
- - <b>`SignatureValidationError`</b>:  if the signature doesn't match 
+**Returns:**
+ True if the signature is valid, False otherwise. 
 
 
 ---

--- a/src-docs/validation.py.md
+++ b/src-docs/validation.py.md
@@ -8,7 +8,7 @@ Module for validating the webhook request.
 
 ---
 
-<a href="../src/validation.py#L14"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/validation.py#L10"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `verify_signature`
 
@@ -36,14 +36,5 @@ Raise error if the signature doesn't match.
 
 **Returns:**
  True if the signature is valid, False otherwise. 
-
-
----
-
-## <kbd>class</kbd> `SignatureValidationError`
-Raised when the signature validation fails. 
-
-
-
 
 

--- a/src-docs/validation.py.md
+++ b/src-docs/validation.py.md
@@ -22,8 +22,6 @@ verify_signature(
 
 Verify that the payload was sent from GitHub by validating SHA256. 
 
-Raise error if the signature doesn't match. 
-
 
 
 **Args:**

--- a/src-docs/validation.py.md
+++ b/src-docs/validation.py.md
@@ -28,7 +28,7 @@ Raise error if the signature doesn't match.
 
 **Args:**
  
- - <b>`payload`</b>:  original request body to verify (request.body()) 
+ - <b>`payload`</b>:  original request body to verify 
  - <b>`secret_token`</b>:  GitHub app webhook token (WEBHOOK_SECRET) 
  - <b>`signature_header`</b>:  header received from GitHub (x-hub-signature-256) 
 

--- a/src/app.py
+++ b/src/app.py
@@ -61,13 +61,16 @@ def handle_github_webhook() -> tuple[str, int]:
     """
     if secret := app.config.get("WEBHOOK_SECRET"):
         if not (signature := request.headers.get(WEBHOOK_SIGNATURE_HEADER)):
+            app.logger.debug(
+                "X-Hub-signature-256 header is missing in request from %s", request.origin
+            )
             return "X-Hub-signature-256 header is missing!", 403
 
         if not verify_signature(
             payload=request.data, secret_token=secret, signature_header=signature
         ):
+            app.logger.debug("Signature validation failed in request from %s", request.origin)
             return "Signature validation failed!", 403
-
     payload = request.get_json()
     app.logger.debug("Received webhook: %s", payload)
     webhook_logger.log(logging.INFO, json.dumps(payload))

--- a/src/app.py
+++ b/src/app.py
@@ -2,21 +2,31 @@
 # See LICENSE file for licensing details.
 
 """Flask application which receives GitHub webhooks and logs those."""
-
+import functools
 import json
 import logging
 import os
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Callable
 
 from flask import Flask, request
+
+from src.validation import SignatureValidationError, verify_signature
+
+WEBHOOK_SIGNATURE_HEADER = "X-Hub-Signature-256"
 
 app = Flask(__name__)
 app.config.from_prefixed_env()
 
 
 webhook_logger = logging.getLogger("webhook_logger")
+webhook_secret = os.environ.get("WEBHOOK_SECRET")
+if webhook_secret:
+    if not isinstance(webhook_secret, str):
+        raise ValueError("WEBHOOK_SECRET must be a string")
+    app.config["WEBHOOK_SECRET"] = webhook_secret
 
 
 def setup_logger(log_file: Path) -> None:
@@ -47,7 +57,41 @@ webhook_logs_dir = Path(os.environ.get("WEBHOOK_LOGS_DIR", "/var/log/whrouter"))
 setup_logger(log_file=webhook_logs_dir / _log_filename())
 
 
+def signature_validator(func: Callable[[], tuple[str, int]]) -> Callable[[], tuple[str, int]]:
+    """Validate the signature of the incoming request.
+
+    Args:
+        func: function to be decorated.
+
+    Returns:
+        Decorated function.
+    """
+
+    @functools.wraps(func)
+    def wrapper() -> tuple[str, int]:
+        """Validate the signature of the incoming request.
+
+        Returns:
+            A tuple containing an error message and 403 status code if the signature is invalid.
+            Otherwise, the result of the decorated function.
+        """
+        if secret := app.config.get("WEBHOOK_SECRET"):
+            request_signature = request.headers.get(WEBHOOK_SIGNATURE_HEADER)
+            if request_signature is None:
+                return "X-Hub-signature-256 header is missing!", 403
+            try:
+                verify_signature(
+                    payload=request.data, secret_token=secret, signature_header=request_signature
+                )
+            except SignatureValidationError:
+                return "Signature validation failed!", 403
+        return func()
+
+    return wrapper
+
+
 @app.route("/webhook", methods=["POST"])
+@signature_validator
 def handle_github_webhook() -> tuple[str, int]:
     """Receive a GitHub webhook and append the payload to a file.
 

--- a/src/app.py
+++ b/src/app.py
@@ -24,8 +24,6 @@ app.config.from_prefixed_env()
 webhook_logger = logging.getLogger("webhook_logger")
 webhook_secret = os.environ.get("WEBHOOK_SECRET")
 if webhook_secret:
-    if not isinstance(webhook_secret, str):
-        raise ValueError("WEBHOOK_SECRET must be a string")
     app.config["WEBHOOK_SECRET"] = webhook_secret
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -60,7 +60,7 @@ def handle_github_webhook() -> tuple[str, int]:
         A tuple containing an empty string and 200 status code.
     """
     if secret := app.config.get("WEBHOOK_SECRET"):
-        if not (signature := request.headers.get("X-Hub-Signature-256")):
+        if not (signature := request.headers.get(WEBHOOK_SIGNATURE_HEADER)):
             return "X-Hub-signature-256 header is missing!", 403
 
         if not verify_signature(

--- a/src/validation.py
+++ b/src/validation.py
@@ -7,10 +7,6 @@ import hashlib
 import hmac
 
 
-class SignatureValidationError(Exception):
-    """Raised when the signature validation fails."""
-
-
 def verify_signature(payload: bytes, secret_token: str, signature_header: str) -> bool:
     """Verify that the payload was sent from GitHub by validating SHA256.
 

--- a/src/validation.py
+++ b/src/validation.py
@@ -11,7 +11,7 @@ class SignatureValidationError(Exception):
     """Raised when the signature validation fails."""
 
 
-def verify_signature(payload: bytes, secret_token: str, signature_header: str) -> None:
+def verify_signature(payload: bytes, secret_token: str, signature_header: str) -> bool:
     """Verify that the payload was sent from GitHub by validating SHA256.
 
     Raise error if the signature doesn't match.
@@ -21,10 +21,9 @@ def verify_signature(payload: bytes, secret_token: str, signature_header: str) -
         secret_token: GitHub app webhook token (WEBHOOK_SECRET)
         signature_header: header received from GitHub (x-hub-signature-256)
 
-    Raises:
-        SignatureValidationError: if the signature doesn't match
+    Returns:
+        True if the signature is valid, False otherwise.
     """
     hash_object = hmac.new(secret_token.encode("utf-8"), msg=payload, digestmod=hashlib.sha256)
     expected_signature = "sha256=" + hash_object.hexdigest()
-    if not hmac.compare_digest(expected_signature, signature_header):
-        raise SignatureValidationError()
+    return hmac.compare_digest(expected_signature, signature_header)

--- a/src/validation.py
+++ b/src/validation.py
@@ -10,8 +10,6 @@ import hmac
 def verify_signature(payload: bytes, secret_token: str, signature_header: str) -> bool:
     """Verify that the payload was sent from GitHub by validating SHA256.
 
-    Raise error if the signature doesn't match.
-
     Args:
         payload: original request body to verify
         secret_token: GitHub app webhook token (WEBHOOK_SECRET)

--- a/src/validation.py
+++ b/src/validation.py
@@ -17,7 +17,7 @@ def verify_signature(payload: bytes, secret_token: str, signature_header: str) -
     Raise error if the signature doesn't match.
 
     Args:
-        payload: original request body to verify (request.body())
+        payload: original request body to verify
         secret_token: GitHub app webhook token (WEBHOOK_SECRET)
         signature_header: header received from GitHub (x-hub-signature-256)
 

--- a/src/validation.py
+++ b/src/validation.py
@@ -1,0 +1,30 @@
+#  Copyright 2024 Canonical Ltd.
+#  See LICENSE file for licensing details.
+
+"""Module for validating the webhook request."""
+
+import hashlib
+import hmac
+
+
+class SignatureValidationError(Exception):
+    """Raised when the signature validation fails."""
+
+
+def verify_signature(payload: bytes, secret_token: str, signature_header: str) -> None:
+    """Verify that the payload was sent from GitHub by validating SHA256.
+
+    Raise error if the signature doesn't match.
+
+    Args:
+        payload: original request body to verify (request.body())
+        secret_token: GitHub app webhook token (WEBHOOK_SECRET)
+        signature_header: header received from GitHub (x-hub-signature-256)
+
+    Raises:
+        SignatureValidationError: if the signature doesn't match
+    """
+    hash_object = hmac.new(secret_token.encode("utf-8"), msg=payload, digestmod=hashlib.sha256)
+    expected_signature = "sha256=" + hash_object.hexdigest()
+    if not hmac.compare_digest(expected_signature, signature_header):
+        raise SignatureValidationError()

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -5,7 +5,6 @@
 import hashlib
 import hmac
 import json
-import os
 import random
 import secrets
 
@@ -59,7 +58,6 @@ def app_fixture(
 ) -> Iterator[None]:
     """Setup and run the flask app."""
     monkeypatch.setenv("WEBHOOK_LOGS_DIR", str(webhook_logs_dir))
-    os.environ["WEBHOOK_LOGS_DIR"] = str(webhook_logs_dir)
     if webhook_secret:
         monkeypatch.setenv("WEBHOOK_SECRET", webhook_secret)
 

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -17,6 +17,7 @@ from typing import Iterator, Optional
 
 import pytest
 import requests
+from flask import Flask
 
 from src.app import WEBHOOK_SIGNATURE_HEADER
 
@@ -49,9 +50,12 @@ def webhook_secret_fixture(request) -> Optional[str]:
     return secrets.token_hex(16) if request.param else None
 
 
-@pytest.fixture(name="app", autouse=True)
+@pytest.fixture(name="app")
 def app_fixture(
-    webhook_logs_dir: Path, process_count: int, webhook_secret: Optional[str], monkeypatch: pytest.MonkeyPatch
+    webhook_logs_dir: Path,
+    process_count: int,
+    webhook_secret: Optional[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> Iterator[None]:
     """Setup and run the flask app."""
     monkeypatch.setenv("WEBHOOK_LOGS_DIR", str(webhook_logs_dir))
@@ -106,7 +110,11 @@ def _request(payload: dict, webhook_secret: Optional[str]) -> requests.Response:
 
 
 def test_receive_webhook(
-    webhook_logs_dir: Path, process_count: int, webhook_secret: Optional[str]
+    webhook_logs_dir: Path,
+    process_count: int,
+    webhook_secret: Optional[str],
+    # app argument is not used here but necessary for the fixture to run
+    app: Flask,  # pylint: disable = unused-argument
 ):
     """
     arrange: given a running app with a process count and a webhook logs directory

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -16,7 +16,6 @@ from typing import Iterator, Optional
 
 import pytest
 import requests
-from flask import Flask
 
 from src.app import WEBHOOK_SIGNATURE_HEADER
 
@@ -107,12 +106,11 @@ def _request(payload: dict, webhook_secret: Optional[str]) -> requests.Response:
     return requests.post(f"{BASE_URL}/webhook", data=payload_bytes, headers=headers, timeout=1)
 
 
+@pytest.mark.usefixtures("app")
 def test_receive_webhook(
     webhook_logs_dir: Path,
     process_count: int,
     webhook_secret: Optional[str],
-    # app argument is not used here but necessary for the fixture to run
-    app: Flask,  # pylint: disable = unused-argument
 ):
     """
     arrange: given a running app with a process count and a webhook logs directory

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -45,12 +45,14 @@ def process_count_fixture() -> int:
     params=[pytest.param(True, id="with_secret"), pytest.param(False, id="without_secret")],
 )
 def webhook_secret_fixture(request) -> Optional[str]:
-    """Return a webhook secret."""
+    """Return a webhook secret or None."""
     return secrets.token_hex(16) if request.param else None
 
 
 @pytest.fixture(name="app", autouse=True)
-def app_fixture(webhook_logs_dir: Path, process_count: int, webhook_secret: str) -> Iterator[None]:
+def app_fixture(
+    webhook_logs_dir: Path, process_count: int, webhook_secret: Optional[str]
+) -> Iterator[None]:
     """Setup and run the flask app."""
     os.environ["WEBHOOK_LOGS_DIR"] = str(webhook_logs_dir)
     if webhook_secret:
@@ -100,7 +102,6 @@ def _request(payload: dict, webhook_secret: Optional[str]) -> requests.Response:
         )
         signature = "sha256=" + hash_object.hexdigest()
         headers[WEBHOOK_SIGNATURE_HEADER] = signature
-        return requests.post(f"{BASE_URL}/webhook", data=payload_bytes, headers=headers, timeout=1)
 
     return requests.post(f"{BASE_URL}/webhook", data=payload_bytes, headers=headers, timeout=1)
 

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -51,14 +51,13 @@ def webhook_secret_fixture(request) -> Optional[str]:
 
 @pytest.fixture(name="app", autouse=True)
 def app_fixture(
-    webhook_logs_dir: Path, process_count: int, webhook_secret: Optional[str]
+    webhook_logs_dir: Path, process_count: int, webhook_secret: Optional[str], monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[None]:
     """Setup and run the flask app."""
+    monkeypatch.setenv("WEBHOOK_LOGS_DIR", str(webhook_logs_dir))
     os.environ["WEBHOOK_LOGS_DIR"] = str(webhook_logs_dir)
     if webhook_secret:
-        os.environ["WEBHOOK_SECRET"] = webhook_secret
-    else:
-        os.environ.pop("WEBHOOK_SECRET", None)
+        monkeypatch.setenv("WEBHOOK_SECRET", webhook_secret)
 
     # use subprocess to run the app using gunicorn with multiple workers
     command = f"gunicorn -w {process_count} --bind {BIND_HOST}:{BIND_PORT} src.app:app"

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,5 +1,8 @@
 #  Copyright 2024 Canonical Ltd.
 #  See LICENSE file for licensing details.
+
+"""Helper functions for the unit tests."""
+
 import hashlib
 import hmac
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,31 @@
+#  Copyright 2024 Canonical Ltd.
+#  See LICENSE file for licensing details.
+import hashlib
+import hmac
+
+
+def create_correct_signature(secret: str, payload: bytes) -> str:
+    """Create a correct webhook signature.
+
+    Args:
+        secret: The secret.
+        payload: The payload.
+
+    Returns:
+        The correct signature.
+    """
+    hash_object = hmac.new(secret.encode("utf-8"), msg=payload, digestmod=hashlib.sha256)
+    return "sha256=" + hash_object.hexdigest()
+
+
+def create_incorrect_signature(secret: str, payload: bytes) -> str:
+    """Create an incorrect webhook signature.
+
+    Args:
+        secret: The secret.
+        payload: The payload.
+
+    Returns:
+        The incorrect signature.
+    """
+    return create_correct_signature(secret, payload)[:-1]

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -120,7 +120,8 @@ def test_webhook_validation(
     assert: Expected status code and reason.
     """
     secret = secrets.token_hex(16)
-    payload = json.dumps({"test": "data"}).encode("utf-8")
+    payload_value = secrets.token_hex(16)
+    payload = json.dumps({"value": payload_value}).encode("utf-8")
 
     app_module.app.config["WEBHOOK_SECRET"] = secret
     headers = {"Content-Type": "application/json"}

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -15,20 +15,19 @@ def test_verify_signature_match():
     """
     arrange: A payload, a secret, and a correct signature.
     act: verify the signature.
-    assert: No exception is raised.
+    assert: True is returned.
     """
     expected_sig = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17"
 
-    verify_signature(TEST_PAYLOAD, TEST_SECRET, expected_sig)
+    assert verify_signature(TEST_PAYLOAD, TEST_SECRET, expected_sig)
 
 
 def test_verify_signature_mismatch():
     """
     arrange: A payload, a secret, and an invalid signature.
     act: verify the signature.
-    assert: A SignatureValidationError is raised.
+    assert: False is returned.
     """
     expected_sig = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e18"
 
-    with pytest.raises(SignatureValidationError):
-        verify_signature(TEST_PAYLOAD, TEST_SECRET, expected_sig)
+    assert not verify_signature(TEST_PAYLOAD, TEST_SECRET, expected_sig)

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,0 +1,34 @@
+#  Copyright 2024 Canonical Ltd.
+#  See LICENSE file for licensing details.
+
+"""The unit tests for the validation module."""
+import pytest
+
+from src.validation import SignatureValidationError, verify_signature
+
+# Test secrets are not a security issue.
+TEST_SECRET = "It's a Secret to Everybody"  # nosec
+TEST_PAYLOAD = b"Hello, World!"
+
+
+def test_verify_signature_match():
+    """
+    arrange: A payload, a secret, and a correct signature.
+    act: verify the signature.
+    assert: No exception is raised.
+    """
+    expected_sig = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17"
+
+    verify_signature(TEST_PAYLOAD, TEST_SECRET, expected_sig)
+
+
+def test_verify_signature_mismatch():
+    """
+    arrange: A payload, a secret, and an invalid signature.
+    act: verify the signature.
+    assert: A SignatureValidationError is raised.
+    """
+    expected_sig = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e18"
+
+    with pytest.raises(SignatureValidationError):
+        verify_signature(TEST_PAYLOAD, TEST_SECRET, expected_sig)

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -2,32 +2,40 @@
 #  See LICENSE file for licensing details.
 
 """The unit tests for the validation module."""
+import secrets
+from typing import Callable
+
 import pytest
 
-from src.validation import SignatureValidationError, verify_signature
-
-# Test secrets are not a security issue.
-TEST_SECRET = "It's a Secret to Everybody"  # nosec
-TEST_PAYLOAD = b"Hello, World!"
+from src.validation import verify_signature
+from tests.unit.helpers import create_correct_signature, create_incorrect_signature
 
 
-def test_verify_signature_match():
+@pytest.mark.parametrize(
+    "create_signature_fct, expected_return_value",
+    [
+        pytest.param(
+            create_correct_signature,
+            True,
+            id="correct signature",
+        ),
+        pytest.param(
+            create_incorrect_signature,
+            False,
+            id="incorrect signature",
+        ),
+    ],
+)
+def test_verify_signature(
+    create_signature_fct: Callable[[str, bytes], str], expected_return_value: bool
+):
     """
-    arrange: A payload, a secret, and a correct signature.
+    arrange: A payload, a secret, and a signature.
     act: verify the signature.
-    assert: True is returned.
+    assert: The expected return value is returned.
     """
-    expected_sig = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17"
+    secret = secrets.token_hex(16)
+    payload = secrets.token_bytes(16)
+    expected_sig = create_signature_fct(secret, payload)
 
-    assert verify_signature(TEST_PAYLOAD, TEST_SECRET, expected_sig)
-
-
-def test_verify_signature_mismatch():
-    """
-    arrange: A payload, a secret, and an invalid signature.
-    act: verify the signature.
-    assert: False is returned.
-    """
-    expected_sig = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e18"
-
-    assert not verify_signature(TEST_PAYLOAD, TEST_SECRET, expected_sig)
+    assert verify_signature(payload, secret, expected_sig) is expected_return_value

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -31,7 +31,7 @@ def test_verify_signature(
 ):
     """
     arrange: A payload, a secret, and a signature.
-    act: verify the signature.
+    act: Verify the signature.
     assert: The expected return value is returned.
     """
     secret = secrets.token_hex(16)


### PR DESCRIPTION
Applicable spec: ISD-116 (internal)

### Overview

Add (optional) webhook delivery validation as described in https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries

### Rationale

Make sure the webhook comes from GitHub and has not been tampered with.


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

No charm yet, so no docs on charmhub.
<!-- Explanation for any unchecked items above -->
