### PR TITLE
Fix publish-charm workflow

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -12,3 +12,5 @@ jobs:
     secrets: inherit
     with:
       channel: latest/edge
+      charm-directory: charm
+      charmcraft-channel: "latest/edge"


### PR DESCRIPTION
### Overview

Add `charm-directory` and `charmcraft-channel` input to publish-charm workflow.


### Rationale

so that publish-charm is no longer broken. (requires https://github.com/canonical/operator-workflows/pull/283 to land)

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
