### PR TITLE
Add health check endpoint

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,7 +11,6 @@ jobs:
       juju-channel: 3.1/stable
       channel: 1.28-strict/stable
       trivy-image-config: "trivy.yaml"
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner: false
       rockcraft-channel: latest/edge
       charmcraft-channel: latest/edge

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,5 +8,4 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
     with:
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner: false

--- a/src-docs/app.py.md
+++ b/src-docs/app.py.md
@@ -24,6 +24,24 @@ Receive a GitHub webhook and append the payload to a file.
 
 
 **Returns:**
+  A tuple containing an empty string and 200 status code on success or  a failure message and 403 status code. 
+
+
+---
+
+<a href="../webhook_router/app.py#L44"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `health_check`
+
+```python
+health_check() → tuple[str, int]
+```
+
+Health check endpoint. 
+
+
+
+**Returns:**
   A tuple containing an empty string and 200 status code. 
 
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -110,3 +110,14 @@ def test_webhook_validation(
 
     assert response.status_code == expected_status
     assert response.text == expected_reason
+
+
+def test_health_check(client: FlaskClient):
+    """
+    arrange: A test client.
+    act: Request the health check endpoint.
+    assert: 200 status code is returned.
+    """
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.data == b""

--- a/webhook_router/app.py
+++ b/webhook_router/app.py
@@ -20,7 +20,8 @@ def handle_github_webhook() -> tuple[str, int]:
     """Receive a GitHub webhook and append the payload to a file.
 
     Returns:
-        A tuple containing an empty string and 200 status code.
+        A tuple containing an empty string and 200 status code on success or
+        a failure message and 403 status code.
     """
     if secret := app.config.get("WEBHOOK_SECRET"):
         if not (signature := request.headers.get(WEBHOOK_SIGNATURE_HEADER)):
@@ -37,6 +38,16 @@ def handle_github_webhook() -> tuple[str, int]:
     payload = request.get_json()
     app.logger.debug("Received webhook: %s", payload)
     app.logger.info(json.dumps(payload))
+    return "", 200
+
+
+@app.route("/health", methods=["GET"])
+def health_check() -> tuple[str, int]:
+    """Health check endpoint.
+
+    Returns:
+        A tuple containing an empty string and 200 status code.
+    """
     return "", 200
 
 


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Add health check endpoint (also remove self-hosted runners from CI due to capacity issues).

### Rationale

which can be probed by reverse proxies to check if a backend is alive.

### Juju Events Changes

n/a

### Module Changes

`webhook_router/app.py`: add the health check endpoint

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
