### PR TITLE
Add config option to set log level

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,11 +4,64 @@
 """The main entry point for the charmed webhook router."""
 import logging
 
+from flask import Flask
+
 # The charm sets up gunicorn to use an app.py file with a flask app named app.
 from webhook_router.app import app
 
+
+class ConfigError(Exception):
+    """Raised when a configuration error occurs."""
+
+    pass
+
+
+def _set_up_logging(app: Flask) -> None:
+    """Set up logging for the application.
+
+    Raises:
+        ConfigError: If the log level is invalid.
+    """
+    _set_log_handlers(app)
+    _set_log_level(app)
+
+
+def _set_log_handlers(app: Flask) -> None:
+    """Set the log handlers of the application.
+
+    Args:
+        app: The Flask application.
+    """
+    # we use the gunicorn logger to ensure that logs are captured and transmitted to loki
+    gunicorn_logger = logging.getLogger('gunicorn.error')
+    app.logger.handlers = gunicorn_logger.handlers
+
+
+def _set_log_level(app: Flask) -> None:
+    """Set the log level of the application.
+
+    Args:
+        app: The Flask application.
+
+    Raises:
+        ConfigError: If the log level is invalid.
+    """
+    level_name_mapping = {
+        'CRITICAL': logging.CRITICAL,
+        'FATAL': logging.FATAL,
+        'ERROR': logging.ERROR,
+        'WARN': logging.WARNING,
+        'WARNING': logging.WARNING,
+        'INFO': logging.INFO,
+        'DEBUG': logging.DEBUG,
+        'NOTSET': logging.NOTSET,
+    }
+    try:
+        level = level_name_mapping[app.config.get("LOG_LEVEL", "INFO")]
+    except KeyError:
+        raise ConfigError(f"Invalid log level: {app.config.get('LOG_LEVEL')}")
+    app.logger.setLevel(level)
+
+
 # the charm will run this file with gunicorn, so we need to set up logging
-# we use the gunicorn logger to ensure that logs are captured and transmitted to loki
-gunicorn_logger = logging.getLogger('gunicorn.error')
-app.logger.handlers = gunicorn_logger.handlers
-app.logger.setLevel(gunicorn_logger.level)
+_set_up_logging(app)

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -25,6 +25,10 @@ extensions:
 
 config:
   options:
+    log-level:
+        type: string
+        description: "The log level to use for the application logs"
+        default: "INFO"
     webhook-secret:
       type: string
       description: "The secret used to validate the webhook"

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -27,7 +27,7 @@ config:
   options:
     log-level:
         type: string
-        description: "The log level to use for the application logs"
+        description: "The log level to use for the application logs. Use any of CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET"
         default: "INFO"
     webhook-secret:
       type: string

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -27,7 +27,7 @@ config:
   options:
     log-level:
         type: string
-        description: "The log level to use for the application logs. Use any of CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET"
+        description: "The log level to use for the application logs. Use any of: CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET"
         default: "INFO"
     webhook-secret:
       type: string


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Add a configuration option to set the log level.

### Rationale

Paas-app-charmer runs gunicorn with default flags (which [sets the log level to info](https://docs.gunicorn.org/en/stable/settings.html#loglevel)) and there is no configuration option to change this.

### Juju Events Changes

n/a

### Module Changes

`app.py`: Added parsing of log level config and setting the level accordingly.

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
