### PR TITLE
Move inputs to promote charm

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -23,4 +23,6 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
+      charm-directory: "charm"
+      doc-automation-disabled: true
     secrets: inherit

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -14,5 +14,3 @@ jobs:
       channel: latest/edge
       charmcraft-channel: "latest/edge"
       resource-mapping: '{"github-runner-webhook-router": "flask-app-image"}'
-      charm-directory: "charm"
-      doc-automation-disabled: true


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Move the `charm-directory` and `doc-automation-disabled` inputs from the publish charm to promote the charm.

### Rationale

The inputs break the publish charm action and must be placed in the promote charm workflow.

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
