### PR TITLE
Remove event key validation

### DIFF
--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -203,7 +203,7 @@ async def test_receive_webhook_client_error(model: Model, app: Application):
     assert resp.status_code == 400
 
     # 5. invalid payload
-    actual_payload = {"event": "workflow_job", "payload": {"action": "queued"}}
+    actual_payload = {"payload": {"action": "queued"}}
     actual_payload_bytes = json.dumps(actual_payload).encode("utf-8")
     actual_signature = _create_signature(actual_payload_bytes, webhook_secret)
     actual_headers = {
@@ -228,7 +228,6 @@ def _create_valid_data(action: str, labels: list[str]) -> dict:
     # we are not using random.randint here for cryptographic purposes
     _id = random.randint(1, 10000)  # nosec
     return {
-        "event": SUPPORTED_GITHUB_EVENT,
         "payload": {
             "action": action,
             "workflow_job": {

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -98,24 +98,6 @@ def test_webhook_invalid_values(labels: list[str], status: JobStatus, run_url: s
     assert "Failed to create Webhook object for payload " in str(exc_info.value)
 
 
-def test_webhook_wrong_event():
-    """
-    arrange: A payload dict with the wrong event.
-    act: Call webhook_to_job with the payload.
-    assert: A ParseError is raised.
-    """
-    payload = {
-        "event": "workflow_run",
-        "payload": {
-            "action": "queued",
-            "workflow_job": {"id": 22428484402, "run_url": FAKE_RUN_URL, "labels": FAKE_LABELS},
-        },
-    }
-    with pytest.raises(ParseError) as exc_info:
-        webhook_to_job(payload)
-    assert f"Event workflow_run not supported: {payload}" in str(exc_info.value)
-
-
 def test_webhook_workflow_job_not_dict():
     """
     arrange: A payload dict with workflow_job not a dict.
@@ -141,16 +123,6 @@ def test_webhook_missing_keys():
     assert: A ParseError is raised.
     """
     payload: dict
-    # event key missing
-    payload = {
-        "payload": {
-            "action": "queued",
-            "workflow_job": {"id": 22428484402, "run_url": FAKE_RUN_URL, "labels": FAKE_LABELS},
-        }
-    }
-    with pytest.raises(ParseError) as exc_info:
-        webhook_to_job(payload)
-    assert f"event key not found in {payload}" in str(exc_info.value)
 
     # payload key missing
     payload = {

--- a/webhook_router/parse.py
+++ b/webhook_router/parse.py
@@ -103,31 +103,10 @@ def _validate_webhook(webhook: dict) -> ValidationResult:
     Returns:
         (True, "") if the payload is valid otherwise (False, error_msg)
     """
-    validation_result = _validate_event(webhook)
-    if not validation_result.is_valid:
-        return validation_result
-
     validation_result = _validate_missing_keys(webhook)
     if not validation_result.is_valid:
         return validation_result
 
-    return ValidationResult(True, "")
-
-
-def _validate_event(webhook: dict) -> ValidationResult:
-    """Validate the event key in the webhook payload.
-
-    Args:
-        webhook: The webhook payload to validate.
-
-    Returns:
-        (True, "") if the event key is valid otherwise (False,error_msg)
-    """
-    if "event" not in webhook:
-        return ValidationResult(False, f"event key not found in {webhook}")
-    event = webhook["event"]
-    if event != WORKFLOW_JOB:
-        return ValidationResult(False, f"Event {event} not supported: {webhook}")
     return ValidationResult(True, "")
 
 


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Remove the event key validation.

### Rationale
This key does not exist. (See https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_job). This results in 400 errors when receiving webhooks.

### Juju Events Changes

n/a

### Module Changes

`parse.py`: Remove `_validate_event`

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
