### PR TITLE
Remove payload key

### DIFF
--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -228,16 +228,14 @@ def _create_valid_data(action: str, labels: list[str]) -> dict:
     # we are not using random.randint here for cryptographic purposes
     _id = random.randint(1, 10000)  # nosec
     return {
-        "payload": {
-            "action": action,
-            "workflow_job": {
-                "id": _id,
-                "run_id": 987654321,
-                "status": "completed",
-                "conclusion": "success",
-                "labels": labels,
-                "run_url": f"https://api.github.com/repos/f/actions/runs/{_id}",
-            },
+        "action": action,
+        "workflow_job": {
+            "id": _id,
+            "run_id": 987654321,
+            "status": "completed",
+            "conclusion": "success",
+            "labels": labels,
+            "run_url": f"https://api.github.com/repos/f/actions/runs/{_id}",
         },
     }
 

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -90,9 +90,9 @@ async def test_forward_webhook(  # pylint: disable=too-many-locals
     expected_jobs_by_flavour = {
         flavour: [
             Job(
-                status=payload["payload"]["action"],
-                run_url=payload["payload"]["workflow_job"]["run_url"],
-                labels=payload["payload"]["workflow_job"]["labels"],
+                status=payload["action"],
+                run_url=payload["workflow_job"]["run_url"],
+                labels=payload["workflow_job"]["labels"],
             )
             for payload in payloads_by_flavour[flavour]
         ]

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -109,9 +109,9 @@ def test_webhook_logs(
     """
     data = _create_valid_data(JobStatus.QUEUED)
     expected_job = Job(
-        labels=data["payload"]["workflow_job"]["labels"],
+        labels=data["workflow_job"]["labels"],
         status=JobStatus.QUEUED,
-        run_url=data["payload"]["workflow_job"]["run_url"],
+        run_url=data["workflow_job"]["run_url"],
     )
     response = client.post(
         TEST_PATH,
@@ -386,16 +386,13 @@ def _create_valid_data(action: str) -> dict:
         A valid payload for the supported event.
     """
     return {
-        "event": app_module.SUPPORTED_GITHUB_EVENT,
-        "payload": {
-            "action": action,
-            "workflow_job": {
-                "id": 123456789,
-                "run_id": 987654321,
-                "status": "completed",
-                "conclusion": "success",
-                "labels": ["self-hosted", "linux", "arm64"],
-                "run_url": "https://api.github.com/repos/f/actions/runs/8200803099",
-            },
+        "action": action,
+        "workflow_job": {
+            "id": 123456789,
+            "run_id": 987654321,
+            "status": "completed",
+            "conclusion": "success",
+            "labels": ["self-hosted", "linux", "arm64"],
+            "run_url": "https://api.github.com/repos/f/actions/runs/8200803099",
         },
     }

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -28,34 +28,31 @@ def test_webhook_to_job(labels: list[str], status: JobStatus):
     assert: The payload is translated.
     """
     payload = {
-        "event": "workflow_job",
-        "payload": {
-            "action": status,
-            "workflow_job": {
-                "id": 22428484402,
-                "run_id": 8200803099,
-                "workflow_name": "Push Event Tests",
-                "head_branch": "github-hosted",
-                "run_url": FAKE_RUN_URL,
-                "run_attempt": 5,
-                "node_id": "CR_kwDOKQMbDc8AAAAFONeDMg",
-                "head_sha": "fc670c970f0c5e156a94d1935776d7ed43728067",
-                "url": "https://api.github.com/repos/f/actions/jobs/22428484402",
-                "html_url": "https://github.com/f/actions/runs/8200803099/job/22428484402",
-                "status": "queued",
-                "conclusion": None,
-                "created_at": "2024-03-08T08:46:26Z",
-                "started_at": "2024-03-08T08:46:26Z",
-                "completed_at": None,
-                "name": "push-event-tests",
-                "steps": [],
-                "check_run_url": "https://api.github.com/repos/f/check-runs/22428484402",
-                "labels": labels,
-                "runner_id": None,
-                "runner_name": None,
-                "runner_group_id": None,
-                "runner_group_name": None,
-            },
+        "action": status,
+        "workflow_job": {
+            "id": 22428484402,
+            "run_id": 8200803099,
+            "workflow_name": "Push Event Tests",
+            "head_branch": "github-hosted",
+            "run_url": FAKE_RUN_URL,
+            "run_attempt": 5,
+            "node_id": "CR_kwDOKQMbDc8AAAAFONeDMg",
+            "head_sha": "fc670c970f0c5e156a94d1935776d7ed43728067",
+            "url": "https://api.github.com/repos/f/actions/jobs/22428484402",
+            "html_url": "https://github.com/f/actions/runs/8200803099/job/22428484402",
+            "status": "queued",
+            "conclusion": None,
+            "created_at": "2024-03-08T08:46:26Z",
+            "started_at": "2024-03-08T08:46:26Z",
+            "completed_at": None,
+            "name": "push-event-tests",
+            "steps": [],
+            "check_run_url": "https://api.github.com/repos/f/check-runs/22428484402",
+            "labels": labels,
+            "runner_id": None,
+            "runner_name": None,
+            "runner_group_id": None,
+            "runner_group_name": None,
         },
     }
 
@@ -87,15 +84,12 @@ def test_webhook_invalid_values(labels: list[str], status: JobStatus, run_url: s
     assert: A ParseError is raised.
     """
     payload = {
-        "event": "workflow_job",
-        "payload": {
-            "action": status,
-            "workflow_job": {"id": 22428484402, "run_url": run_url, "labels": labels},
-        },
+        "action": status,
+        "workflow_job": {"id": 22428484402, "run_url": run_url, "labels": labels},
     }
     with pytest.raises(ParseError) as exc_info:
         webhook_to_job(payload)
-    assert "Failed to create Webhook object for payload " in str(exc_info.value)
+    assert "Failed to create Webhook object for webhook " in str(exc_info.value)
 
 
 def test_webhook_workflow_job_not_dict():
@@ -105,11 +99,8 @@ def test_webhook_workflow_job_not_dict():
     assert: A ParseError is raised.
     """
     payload = {
-        "event": "workflow_job",
-        "payload": {
-            "action": "queued",
-            "workflow_job": "not a dict",
-        },
+        "action": "queued",
+        "workflow_job": "not a dict",
     }
     with pytest.raises(ParseError) as exc_info:
         webhook_to_job(payload)
@@ -124,19 +115,8 @@ def test_webhook_missing_keys():
     """
     payload: dict
 
-    # payload key missing
-    payload = {
-        "event": "workflow_job",
-        "action": "queued",
-        "workflow_job": {"id": 22428484402, "run_url": FAKE_RUN_URL, "labels": FAKE_LABELS},
-    }
-    with pytest.raises(ParseError) as exc_info:
-        webhook_to_job(payload)
-    assert f"payload key not found in {payload}" in str(exc_info.value)
-
     # action key is missing
     payload = {
-        "event": "workflow_job",
         "payload": {
             "workflow_job": {"id": 22428484402, "run_url": FAKE_RUN_URL, "labels": FAKE_LABELS},
         },
@@ -146,13 +126,10 @@ def test_webhook_missing_keys():
     assert f"action key not found in {payload}" in str(exc_info.value)
     # workflow_job key missing
     payload = {
-        "event": "workflow_job",
-        "payload": {
-            "action": "queued",
-            "id": 22428484402,
-            "run_url": FAKE_RUN_URL,
-            "labels": FAKE_LABELS,
-        },
+        "action": "queued",
+        "id": 22428484402,
+        "run_url": FAKE_RUN_URL,
+        "labels": FAKE_LABELS,
     }
     with pytest.raises(ParseError) as exc_info:
         webhook_to_job(payload)
@@ -160,11 +137,8 @@ def test_webhook_missing_keys():
 
     # labels key missing
     payload = {
-        "event": "workflow_job",
-        "payload": {
-            "action": "queued",
-            "workflow_job": {"id": 22428484402, "run_url": FAKE_RUN_URL},
-        },
+        "action": "queued",
+        "workflow_job": {"id": 22428484402, "run_url": FAKE_RUN_URL},
     }
     with pytest.raises(ParseError) as exc_info:
         webhook_to_job(payload)
@@ -172,11 +146,8 @@ def test_webhook_missing_keys():
 
     # run_url key missing
     payload = {
-        "event": "workflow_job",
-        "payload": {
-            "action": "queued",
-            "workflow_job": {"id": 22428484402, "labels": FAKE_LABELS},
-        },
+        "action": "queued",
+        "workflow_job": {"id": 22428484402, "labels": FAKE_LABELS},
     }
     with pytest.raises(ParseError) as exc_info:
         webhook_to_job(payload)


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Remove accessing the `payload` key when parsing the webhook payload.

### Rationale

The key is non-existent. The webhook payload has the form

```
{
  'action': 'queued',
  'workflow_job': {
    'id': 28406633456,
    'run_id': 10262527884,
    'workflow_name': 'CI',
    'head_branch': 'push-test',
    'run_url': 'https://api.github.com/repos/canonical/cbartz-runner-testing/actions/runs/10262527884',
    'labels': [
      'self-hosted',
      'large'
    ],
  ...
  },
  'repository': {
...
  },
  'organization': {
...
  },
  'enterprise': {
...
  },
  'sender': {
...
  }
}
```
see also https://pastebin.canonical.com/p/zYhYJ53Rnq/

### Juju Events Changes

n/a

### Module Changes
`parse.py`: Do not assume the existence of the `payload` key in the payload.

### Library Changes
n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
