### PR TITLE
Use url instead of run_url

### DIFF
--- a/src-docs/parse.py.md
+++ b/src-docs/parse.py.md
@@ -50,7 +50,7 @@ A class to translate the payload.
  
  - <b>`labels`</b>:  The labels of the job. 
  - <b>`status`</b>:  The status of the job. 
- - <b>`run_url`</b>:  The URL of the job. 
+ - <b>`url`</b>:  The URL of the job to be able to check its status. 
 
 
 ---

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -91,7 +91,7 @@ async def test_forward_webhook(  # pylint: disable=too-many-locals
         flavour: [
             Job(
                 status=payload["action"],
-                run_url=payload["workflow_job"]["run_url"],
+                url=payload["workflow_job"]["url"],
                 labels=payload["workflow_job"]["labels"],
             )
             for payload in payloads_by_flavour[flavour]
@@ -235,7 +235,7 @@ def _create_valid_data(action: str, labels: list[str]) -> dict:
             "status": "completed",
             "conclusion": "success",
             "labels": labels,
-            "run_url": f"https://api.github.com/repos/f/actions/runs/{_id}",
+            "url": f"10262527884/job/28406633456https://api.github.com/repos/f/actions/jobs/{_id}",
         },
     }
 

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -235,7 +235,7 @@ def _create_valid_data(action: str, labels: list[str]) -> dict:
             "status": "completed",
             "conclusion": "success",
             "labels": labels,
-            "url": f"10262527884/job/28406633456https://api.github.com/repos/f/actions/jobs/{_id}",
+            "url": f"https://api.github.com/repos/f/actions/jobs/{_id}",
         },
     }
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -111,7 +111,7 @@ def test_webhook_logs(
     expected_job = Job(
         labels=data["workflow_job"]["labels"],
         status=JobStatus.QUEUED,
-        run_url=data["workflow_job"]["run_url"],
+        url=data["workflow_job"]["url"],
     )
     response = client.post(
         TEST_PATH,
@@ -393,6 +393,6 @@ def _create_valid_data(action: str) -> dict:
             "status": "completed",
             "conclusion": "success",
             "labels": ["self-hosted", "linux", "arm64"],
-            "run_url": "https://api.github.com/repos/f/actions/runs/8200803099",
+            "url": "https://api.github.com/repos/f/actions/jobs/8200803099",
         },
     }

--- a/tests/unit/test_mq.py
+++ b/tests/unit/test_mq.py
@@ -30,8 +30,8 @@ def test_add_job_to_queue():
     """
     flavor = secrets.token_hex(16)
     labels = [secrets.token_hex(16), secrets.token_hex(16)]
-    # mypy: does not recognize that run_url can be passed as a string
-    job = Job(labels=labels, status=JobStatus.QUEUED, run_url="http://example.com")  # type: ignore
+    # mypy: does not recognize that url can be passed as a string
+    job = Job(labels=labels, status=JobStatus.QUEUED, url="http://example.com")  # type: ignore
     mq.add_job_to_queue(job, flavor)
 
     with Connection(IN_MEMORY_URI) as conn:

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -7,7 +7,7 @@ import pytest
 
 from webhook_router.parse import Job, JobStatus, ParseError, webhook_to_job
 
-FAKE_RUN_URL = "https://api.github.com/repos/fakeusergh-runner-test/actions/runs/8200803099"
+FAKE_JOB_URL = "https://api.github.com/repos/fakeusergh-runner-test/actions/jobs/8200803099"
 FAKE_LABELS = ["self-hosted", "linux", "arm64"]
 
 
@@ -34,11 +34,11 @@ def test_webhook_to_job(labels: list[str], status: JobStatus):
             "run_id": 8200803099,
             "workflow_name": "Push Event Tests",
             "head_branch": "github-hosted",
-            "run_url": FAKE_RUN_URL,
+            "run_url": "https://api.github.com/repos/canonical/f/actions/runs/8200803099",
             "run_attempt": 5,
             "node_id": "CR_kwDOKQMbDc8AAAAFONeDMg",
             "head_sha": "fc670c970f0c5e156a94d1935776d7ed43728067",
-            "url": "https://api.github.com/repos/f/actions/jobs/22428484402",
+            "url": FAKE_JOB_URL,
             "html_url": "https://github.com/f/actions/runs/8200803099/job/22428484402",
             "status": "queued",
             "conclusion": None,
@@ -47,7 +47,7 @@ def test_webhook_to_job(labels: list[str], status: JobStatus):
             "completed_at": None,
             "name": "push-event-tests",
             "steps": [],
-            "check_run_url": "https://api.github.com/repos/f/check-runs/22428484402",
+            "check_url": "https://api.github.com/repos/f/check-runs/22428484402",
             "labels": labels,
             "runner_id": None,
             "runner_name": None,
@@ -60,24 +60,24 @@ def test_webhook_to_job(labels: list[str], status: JobStatus):
 
     # mypy does not understand that we can pass strings instead of HttpUrl objects
     # because of the underlying pydantic magic
-    assert result == Job(labels=labels, status=status, run_url=FAKE_RUN_URL)  # type: ignore
+    assert result == Job(labels=labels, status=status, url=FAKE_JOB_URL)  # type: ignore
 
 
 @pytest.mark.parametrize(
-    "labels, status, run_url",
+    "labels, status, url",
     [
         pytest.param(
-            ["self-hosted", "linux", "arm64"], "invalid", FAKE_RUN_URL, id="invalid status"
+            ["self-hosted", "linux", "arm64"], "invalid", FAKE_JOB_URL, id="invalid status"
         ),
         pytest.param(["ubuntu-latest"], JobStatus.IN_PROGRESS, "invalid", id="invalid run url"),
-        pytest.param(None, JobStatus.IN_PROGRESS, FAKE_RUN_URL, id="missing labels"),
-        pytest.param(["self-hosted", "linux", "amd"], None, FAKE_RUN_URL, id="missing status"),
+        pytest.param(None, JobStatus.IN_PROGRESS, FAKE_JOB_URL, id="missing labels"),
+        pytest.param(["self-hosted", "linux", "amd"], None, FAKE_JOB_URL, id="missing status"),
         pytest.param(
             ["self-hosted", "linux", "amd"], JobStatus.COMPLETED, None, id="missing run url"
         ),
     ],
 )
-def test_webhook_invalid_values(labels: list[str], status: JobStatus, run_url: str):
+def test_webhook_invalid_values(labels: list[str], status: JobStatus, url: str):
     """
     arrange: A payload dict with invalid values.
     act: Call webhook_to_job with the payload.
@@ -85,7 +85,7 @@ def test_webhook_invalid_values(labels: list[str], status: JobStatus, run_url: s
     """
     payload = {
         "action": status,
-        "workflow_job": {"id": 22428484402, "run_url": run_url, "labels": labels},
+        "workflow_job": {"id": 22428484402, "url": url, "labels": labels},
     }
     with pytest.raises(ParseError) as exc_info:
         webhook_to_job(payload)
@@ -118,7 +118,7 @@ def test_webhook_missing_keys():
     # action key is missing
     payload = {
         "payload": {
-            "workflow_job": {"id": 22428484402, "run_url": FAKE_RUN_URL, "labels": FAKE_LABELS},
+            "workflow_job": {"id": 22428484402, "url": FAKE_JOB_URL, "labels": FAKE_LABELS},
         },
     }
     with pytest.raises(ParseError) as exc_info:
@@ -128,7 +128,7 @@ def test_webhook_missing_keys():
     payload = {
         "action": "queued",
         "id": 22428484402,
-        "run_url": FAKE_RUN_URL,
+        "url": FAKE_JOB_URL,
         "labels": FAKE_LABELS,
     }
     with pytest.raises(ParseError) as exc_info:
@@ -138,17 +138,17 @@ def test_webhook_missing_keys():
     # labels key missing
     payload = {
         "action": "queued",
-        "workflow_job": {"id": 22428484402, "run_url": FAKE_RUN_URL},
+        "workflow_job": {"id": 22428484402, "url": FAKE_JOB_URL},
     }
     with pytest.raises(ParseError) as exc_info:
         webhook_to_job(payload)
     assert f"labels key not found in {payload}" in str(exc_info.value)
 
-    # run_url key missing
+    # url key missing
     payload = {
         "action": "queued",
         "workflow_job": {"id": 22428484402, "labels": FAKE_LABELS},
     }
     with pytest.raises(ParseError) as exc_info:
         webhook_to_job(payload)
-    assert f"run_url key not found in {payload}" in str(exc_info.value)
+    assert f"url key not found in {payload}" in str(exc_info.value)

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -52,7 +52,7 @@ def test_job_is_forwarded(
     job = Job(
         labels=["arm64"],
         status=job_status,
-        run_url="https://api.github.com/repos/f/actions/runs/8200803099",  # type: ignore
+        url="https://api.github.com/repos/f/actions/jobs/8200803099",  # type: ignore
     )
     forward(
         job,
@@ -75,7 +75,7 @@ def test_invalid_label_combination():
     job = Job(
         labels=["self-hosted", "linux", "arm64", "x64"],
         status=JobStatus.QUEUED,
-        run_url="https://api.github.com/repos/f/actions/runs/8200803099",  # type: ignore
+        url="https://api.github.com/repos/f/actions/jobs/8200803099",  # type: ignore
     )
     with pytest.raises(RouterError) as e:
         forward(

--- a/webhook_router/parse.py
+++ b/webhook_router/parse.py
@@ -39,12 +39,12 @@ class Job(BaseModel):
     Attributes:
         labels: The labels of the job.
         status: The status of the job.
-        run_url: The URL of the job.
+        url: The URL of the job to be able to check its status.
     """
 
     labels: list[str]
     status: JobStatus
-    run_url: HttpUrl
+    url: HttpUrl
 
 
 def webhook_to_job(webhook: dict) -> Job:
@@ -71,20 +71,20 @@ def webhook_to_job(webhook: dict) -> Job:
         "labels" in webhook["workflow_job"]
     ), f"labels key not found in {webhook['workflow_job']}"
     assert (  # nosec
-        "run_url" in webhook["workflow_job"]
-    ), f"run_url key not found in {webhook['workflow_job']}"
+        "url" in webhook["workflow_job"]
+    ), f"url key not found in {webhook['workflow_job']}"
 
     status = webhook["action"]
     workflow_job = webhook["workflow_job"]
 
     labels = workflow_job["labels"]
-    run_url = workflow_job["run_url"]
+    job_url = workflow_job["url"]
 
     try:
         return Job(
             labels=labels,
             status=status,
-            run_url=run_url,
+            url=job_url,
         )
     except ValueError as exc:
         raise ParseError(f"Failed to create Webhook object for webhook {webhook}: {exc}") from exc
@@ -125,7 +125,7 @@ def _validate_missing_keys(webhook: dict) -> ValidationResult:
     workflow_job = webhook["workflow_job"]
     if not isinstance(workflow_job, dict):
         return ValidationResult(False, f"workflow_job is not a dict in {webhook}")
-    for expected_workflow_job_key in ("labels", "run_url"):
+    for expected_workflow_job_key in ("labels", "url"):
         if expected_workflow_job_key not in workflow_job:
             return ValidationResult(
                 False, f"{expected_workflow_job_key} key not found in {webhook}"


### PR DESCRIPTION
Applicable spec: [ISD-116](https://discourse.charmhub.io/t/specification-isd116-github-self-hosted-runners-reactive-scheduling/13755)

### Overview

Extract and forward the value of the `url` key instead of `run_url` from the webhook (https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=queued#workflow_job)

### Rationale

The `run_url` contains information about the entire workflow run, which may contain multiple jobs. The Github runner operator needs the status of a particular job, not an entire run, to decide whether or not to spawn a runner.

Example API response when using url: https://pastebin.canonical.com/p/dwMY7sSyqh/
Example API response when using run_url: https://pastebin.canonical.com/p/6D9gTDvkrd/

### Module Changes

`webhook_router.parse.py`: use `url` instead of `run_url`


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->


[ISD-116]: https://warthogs.atlassian.net/browse/ISD-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ