### PR TITLE
Forward repository and job_id instead of job_url

### DIFF
--- a/src-docs/parse.py.md
+++ b/src-docs/parse.py.md
@@ -11,7 +11,7 @@ Module for parsing the webhook payload.
 
 ---
 
-<a href="../webhook_router/parse.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/parse.py#L64"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `webhook_to_job`
 
@@ -41,6 +41,44 @@ Parse a raw json payload and extract the required information.
 
 ---
 
+## <kbd>class</kbd> `GitHubRepo`
+A class to represent the GitHub repository. 
+
+
+
+**Attributes:**
+ 
+ - <b>`owner`</b>:  The owner of the repository. 
+ - <b>`name`</b>:  The name of the repository. 
+
+
+---
+
+#### <kbd>property</kbd> model_extra
+
+Get extra fields set during validation. 
+
+
+
+**Returns:**
+  A dictionary of extra fields, or `None` if `config.extra` is not set to `"allow"`. 
+
+---
+
+#### <kbd>property</kbd> model_fields_set
+
+Returns the set of fields that have been explicitly set on this model instance. 
+
+
+
+**Returns:**
+  A set of strings representing the fields that have been set,  i.e. that were not filled from defaults. 
+
+
+
+
+---
+
 ## <kbd>class</kbd> `Job`
 A class to translate the payload. 
 
@@ -50,7 +88,8 @@ A class to translate the payload.
  
  - <b>`labels`</b>:  The labels of the job. 
  - <b>`status`</b>:  The status of the job. 
- - <b>`url`</b>:  The URL of the job to be able to check its status. 
+ - <b>`repository`</b>:  The repository of the job. 
+ - <b>`id`</b>:  The id of the job. 
 
 
 ---

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -22,7 +22,7 @@ from webhook_router.app import (
     SUPPORTED_GITHUB_EVENT,
     WEBHOOK_SIGNATURE_HEADER,
 )
-from webhook_router.parse import Job, JobStatus
+from webhook_router.parse import GitHubRepo, Job, JobStatus
 
 PORT = 8000
 
@@ -91,8 +91,12 @@ async def test_forward_webhook(  # pylint: disable=too-many-locals
         flavour: [
             Job(
                 status=payload["action"],
-                url=payload["workflow_job"]["url"],
+                id=payload["workflow_job"]["id"],
                 labels=payload["workflow_job"]["labels"],
+                repository=GitHubRepo(
+                    name=payload["repository"]["name"],
+                    owner=payload["repository"]["owner"]["login"],
+                ),
             )
             for payload in payloads_by_flavour[flavour]
         ]
@@ -236,6 +240,13 @@ def _create_valid_data(action: str, labels: list[str]) -> dict:
             "conclusion": "success",
             "labels": labels,
             "url": f"https://api.github.com/repos/f/actions/jobs/{_id}",
+        },
+        "repository": {
+            "id": 123456789,
+            "name": "gh-runner-test",
+            "full_name": "f/gh-runner-test",
+            "private": False,
+            "owner": {"login": "f", "id": 123456},
         },
     }
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -16,7 +16,7 @@ from werkzeug.exceptions import BadRequest, UnsupportedMediaType
 import webhook_router.app as app_module
 import webhook_router.router
 from tests.unit.helpers import create_correct_signature, create_incorrect_signature
-from webhook_router.parse import Job, JobStatus, ParseError
+from webhook_router.parse import GitHubRepo, Job, JobStatus, ParseError
 from webhook_router.router import RouterError, RoutingTable
 
 TEST_PATH = "/webhook"
@@ -111,7 +111,10 @@ def test_webhook_logs(
     expected_job = Job(
         labels=data["workflow_job"]["labels"],
         status=JobStatus.QUEUED,
-        url=data["workflow_job"]["url"],
+        id=data["workflow_job"]["id"],
+        repository=GitHubRepo(
+            owner=data["repository"]["owner"]["login"], name=data["repository"]["name"]
+        ),
     )
     response = client.post(
         TEST_PATH,
@@ -394,5 +397,9 @@ def _create_valid_data(action: str) -> dict:
             "conclusion": "success",
             "labels": ["self-hosted", "linux", "arm64"],
             "url": "https://api.github.com/repos/f/actions/jobs/8200803099",
+        },
+        "repository": {
+            "name": "actions",
+            "owner": {"login": "f"},
         },
     }

--- a/tests/unit/test_mq.py
+++ b/tests/unit/test_mq.py
@@ -10,7 +10,7 @@ from kombu import Connection
 from kombu.exceptions import OperationalError
 
 from webhook_router import mq
-from webhook_router.parse import Job, JobStatus
+from webhook_router.parse import GitHubRepo, Job, JobStatus
 
 IN_MEMORY_URI = "memory://"
 
@@ -30,8 +30,12 @@ def test_add_job_to_queue():
     """
     flavor = secrets.token_hex(16)
     labels = [secrets.token_hex(16), secrets.token_hex(16)]
-    # mypy: does not recognize that url can be passed as a string
-    job = Job(labels=labels, status=JobStatus.QUEUED, url="http://example.com")  # type: ignore
+    job = Job(
+        labels=labels,
+        status=JobStatus.QUEUED,
+        repository=GitHubRepo(owner="fake", name="gh-runner"),
+        id=1234,
+    )
     mq.add_job_to_queue(job, flavor)
 
     with Connection(IN_MEMORY_URI) as conn:

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from webhook_router.mq import add_job_to_queue
-from webhook_router.parse import Job, JobStatus
+from webhook_router.parse import GitHubRepo, Job, JobStatus
 from webhook_router.router import (
     RouterError,
     RoutingTable,
@@ -47,12 +47,11 @@ def test_job_is_forwarded(
     act: Forward the job to the message queue.
     assert: The job is added to the queue if the status is "QUEUED".
     """
-    # mypy does not understand that we can pass strings instead of HttpUrl objects
-    # because of the underlying pydantic magic
     job = Job(
         labels=["arm64"],
         status=job_status,
-        url="https://api.github.com/repos/f/actions/jobs/8200803099",  # type: ignore
+        id=22428484402,
+        repository=GitHubRepo(**{"owner": "fake", "name": "gh-runner-test"}),
     )
     forward(
         job,
@@ -70,12 +69,11 @@ def test_invalid_label_combination():
     act: Forward the job to the message queue.
     assert: A RouterError is raised.
     """
-    # mypy does not understand that we can pass strings instead of HttpUrl objects
-    # because of the underlying pydantic magic
     job = Job(
         labels=["self-hosted", "linux", "arm64", "x64"],
         status=JobStatus.QUEUED,
-        url="https://api.github.com/repos/f/actions/jobs/8200803099",  # type: ignore
+        id=22428484402,
+        repository=GitHubRepo(**{"owner": "fake", "name": "gh-runner-test"}),
     )
     with pytest.raises(RouterError) as e:
         forward(


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Forward repository and job id instead of job_url.

### Rationale

The consumer of the webhook will likely need to decompose the job_url if they are using an abstraction to access GitHub. Providing the essential information, assuming the API remains the same, requires less effort on the consumer side.


### Juju Events Changes
n/a

### Module Changes

`webhook_router.parse`: Implement the logic as described above. Also refactor validation, as linter complained about cognitive complexity, now using recursive function

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
