### PR TITLE
Prevent default labels from being forwarded

### DIFF
--- a/src-docs/app.py.md
+++ b/src-docs/app.py.md
@@ -32,7 +32,7 @@ Configure the application.
 
 ---
 
-<a href="../webhook_router/app.py#L136"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/app.py#L134"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `health_check`
 
@@ -50,7 +50,7 @@ Health check endpoint.
 
 ---
 
-<a href="../webhook_router/app.py#L148"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/app.py#L146"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `handle_github_webhook`
 

--- a/src-docs/app.py.md
+++ b/src-docs/app.py.md
@@ -32,7 +32,7 @@ Configure the application.
 
 ---
 
-<a href="../webhook_router/app.py#L135"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/app.py#L136"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `health_check`
 
@@ -50,7 +50,7 @@ Health check endpoint.
 
 ---
 
-<a href="../webhook_router/app.py#L147"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/app.py#L148"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `handle_github_webhook`
 

--- a/src-docs/parse.py.md
+++ b/src-docs/parse.py.md
@@ -16,7 +16,7 @@ Module for parsing the webhook payload.
 ## <kbd>function</kbd> `webhook_to_job`
 
 ```python
-webhook_to_job(webhook: dict, ignore_labels: Collection[str]) → Job
+webhook_to_job(payload: dict, ignore_labels: Collection[str]) → Job
 ```
 
 Parse a raw json payload and extract the required information. 
@@ -25,7 +25,7 @@ Parse a raw json payload and extract the required information.
 
 **Args:**
  
- - <b>`webhook`</b>:  The webhook in json to parse. 
+ - <b>`payload`</b>:  The webhook's payload in json to parse. 
  - <b>`ignore_labels`</b>:  The labels to ignore when parsing. For example, "self-hosted" or "linux". 
 
 

--- a/src-docs/parse.py.md
+++ b/src-docs/parse.py.md
@@ -11,12 +11,12 @@ Module for parsing the webhook payload.
 
 ---
 
-<a href="../webhook_router/parse.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/parse.py#L52"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `webhook_to_job`
 
 ```python
-webhook_to_job(webhook: dict) → Job
+webhook_to_job(webhook: dict, ignore_labels: Collection[str]) → Job
 ```
 
 Parse a raw json payload and extract the required information. 
@@ -26,6 +26,7 @@ Parse a raw json payload and extract the required information.
 **Args:**
  
  - <b>`webhook`</b>:  The webhook in json to parse. 
+ - <b>`ignore_labels`</b>:  The labels to ignore when parsing. For example, "self-hosted" or "linux". 
 
 
 

--- a/src-docs/router.py.md
+++ b/src-docs/router.py.md
@@ -11,14 +11,13 @@ Module for routing webhooks to the appropriate message queue.
 
 ---
 
-<a href="../webhook_router/router.py#L41"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/router.py#L39"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `to_routing_table`
 
 ```python
 to_routing_table(
     flavor_label_mapping_list: list[tuple[str, list[str]]],
-    ignore_labels: set[str],
     default_flavor: str
 ) → RoutingTable
 ```
@@ -30,7 +29,6 @@ Convert the flavor label mapping to a route table.
 **Args:**
  
  - <b>`flavor_label_mapping_list`</b>:  The list of mappings of flavors to labels. 
- - <b>`ignore_labels`</b>:  The labels to ignore (e.g. "self-hosted" or "linux"). 
  - <b>`default_flavor`</b>:  The default flavor to use if no labels are provided. 
 
 
@@ -41,7 +39,7 @@ Convert the flavor label mapping to a route table.
 
 ---
 
-<a href="../webhook_router/router.py#L97"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/router.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `forward`
 
@@ -67,7 +65,7 @@ Forward the job to the appropriate message queue.
 
 ---
 
-<a href="../webhook_router/router.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/router.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `can_forward`
 
@@ -102,7 +100,6 @@ A class to represent how to route jobs to the appropriate message queue.
 **Attributes:**
  
  - <b>`value`</b>:  The mapping of labels to flavors. 
- - <b>`ignore_labels`</b>:  The labels to ignore (e.g. "self-hosted" or "linux"). 
  - <b>`default_flavor`</b>:  The default flavor. 
 
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -57,7 +57,6 @@ def route_table_fixture() -> RoutingTable:
             ("small", "x64"): "small",
         },
         default_flavor="small",
-        ignore_labels={"self-hosted", "linux"},
     )
 
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -20,6 +20,8 @@ from webhook_router.parse import Job, JobStatus, ParseError
 from webhook_router.router import RouterError, RoutingTable
 
 TEST_PATH = "/webhook"
+TEST_LABELS = ["self-hosted", "linux", "arm64"]
+DEFAULT_SELF_HOSTED_LABELS = {"self-hosted", "linux"}
 
 
 @pytest.fixture(name="flavours_yaml")
@@ -109,7 +111,7 @@ def test_webhook_logs(
     """
     data = _create_valid_data(JobStatus.QUEUED)
     expected_job = Job(
-        labels=data["workflow_job"]["labels"],
+        labels=set(TEST_LABELS) - DEFAULT_SELF_HOSTED_LABELS,
         status=JobStatus.QUEUED,
         url=data["workflow_job"]["url"],
     )
@@ -392,7 +394,7 @@ def _create_valid_data(action: str) -> dict:
             "run_id": 987654321,
             "status": "completed",
             "conclusion": "success",
-            "labels": ["self-hosted", "linux", "arm64"],
+            "labels": TEST_LABELS,
             "url": "https://api.github.com/repos/f/actions/jobs/8200803099",
         },
     }

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -50,7 +50,7 @@ def test_job_is_forwarded(
     # mypy does not understand that we can pass strings instead of HttpUrl objects
     # because of the underlying pydantic magic
     job = Job(
-        labels=["arm64"],
+        labels={"arm64"},
         status=job_status,
         url="https://api.github.com/repos/f/actions/jobs/8200803099",  # type: ignore
     )
@@ -73,7 +73,7 @@ def test_invalid_label_combination():
     # mypy does not understand that we can pass strings instead of HttpUrl objects
     # because of the underlying pydantic magic
     job = Job(
-        labels=["self-hosted", "linux", "arm64", "x64"],
+        labels={"self-hosted", "linux", "arm64", "x64"},
         status=JobStatus.QUEUED,
         url="https://api.github.com/repos/f/actions/jobs/8200803099",  # type: ignore
     )

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -56,9 +56,7 @@ def test_job_is_forwarded(
     )
     forward(
         job,
-        routing_table=RoutingTable(
-            value={("arm64",): "arm64"}, default_flavor="arm64", ignore_labels=set()
-        ),
+        routing_table=RoutingTable(value={("arm64",): "arm64"}, default_flavor="arm64"),
     )
 
     assert add_job_to_queue_mock.called == is_forwarded
@@ -80,7 +78,7 @@ def test_invalid_label_combination():
     with pytest.raises(RouterError) as e:
         forward(
             job,
-            routing_table=RoutingTable(value={}, default_flavor="default", ignore_labels=set()),
+            routing_table=RoutingTable(value={}, default_flavor="default"),
         )
     assert "Not able to forward job: Invalid label combination:" in str(e.value)
 
@@ -93,9 +91,8 @@ def test_to_routing_table():
     """
     flavor_mapping = [("large", ["arm64", "large"]), ("x64-large", ["large", "x64", "jammy"])]
 
-    ignore_labels = {"self-hosted", "linux"}
     default_flavor = "x64-large"
-    routing_table = to_routing_table(flavor_mapping, ignore_labels, default_flavor)
+    routing_table = to_routing_table(flavor_mapping, default_flavor)
     assert routing_table == RoutingTable(
         value={
             ("arm64",): "large",
@@ -109,7 +106,6 @@ def test_to_routing_table():
             ("jammy", "large", "x64"): "x64-large",
         },
         default_flavor="x64-large",
-        ignore_labels=ignore_labels,
     )
 
 
@@ -120,9 +116,8 @@ def test_to_routing_table_case_insensitive():
     assert: A LabelsFlavorMapping object is returned which has all labels in lower case.
     """
     flavor_mapping = [("large", ["arM64", "LaRgE"])]
-    ignore_labels = {"self-HOSTED", "LINux"}
     default_flavor = "large"
-    routing_table = to_routing_table(flavor_mapping, ignore_labels, default_flavor)
+    routing_table = to_routing_table(flavor_mapping, default_flavor)
     assert routing_table == RoutingTable(
         value={
             ("arm64",): "large",
@@ -130,7 +125,6 @@ def test_to_routing_table_case_insensitive():
             ("arm64", "large"): "large",
         },
         default_flavor="large",
-        ignore_labels={"self-hosted", "linux"},
     )
 
 
@@ -172,7 +166,6 @@ def test__labels_to_flavor():
             **{label_combination: "x64-large" for label_combination in x64_label_combination},
         },
         default_flavor="large",
-        ignore_labels={"self-hosted", "linux"},
     )
 
     for label_combination in arm_label_combination:
@@ -200,20 +193,19 @@ def test__labels_to_flavor_case_insensitive():
             ("arm64", "large"): "large",
         },
         default_flavor="large",
-        ignore_labels={"self-hosted", "linux"},
     )
 
     assert _labels_to_flavor({"SMALl"}, routing_table) == "small"
     assert _labels_to_flavor({"ARM64"}, routing_table) == "large"
     assert _labels_to_flavor({"lARGE"}, routing_table) == "large"
     assert _labels_to_flavor({"arM64", "lArge"}, routing_table) == "large"
-    assert _labels_to_flavor({"small", "SELF-hosted"}, routing_table) == "small"
+    assert _labels_to_flavor({"small"}, routing_table) == "small"
 
 
-def test__labels_to_flavor_default_label():
+def test__labels_to_flavor_default_flavor():
     """
     arrange: Two flavors and a labels to flavor routing_table
-    act: Call labels_to_flavor with empty labels or ignored labels.
+    act: Call labels_to_flavor with empty labels.
     assert: The default flavor is returned.
     """
     routing_table = RoutingTable(
@@ -225,12 +217,8 @@ def test__labels_to_flavor_default_label():
             ("large", "x64"): "x64-large",
         },
         default_flavor="large",
-        ignore_labels={"self-hosted", "linux"},
     )
     assert _labels_to_flavor(set(), routing_table) == "large"
-    assert _labels_to_flavor({"self-hosted"}, routing_table) == "large"
-    assert _labels_to_flavor({"linux"}, routing_table) == "large"
-    assert _labels_to_flavor({"self-hosted", "linux"}, routing_table) == "large"
 
 
 def test__labels_to_flavor_invalid_combination():
@@ -248,7 +236,6 @@ def test__labels_to_flavor_invalid_combination():
             ("large", "x64"): "x64-large",
         },
         default_flavor="large",
-        ignore_labels={"self-hosted", "linux"},
     )
     labels = {"self-hosted", "linux", "arm64", "large", "x64"}
     with pytest.raises(_InvalidLabelCombinationError) as exc_info:
@@ -271,30 +258,8 @@ def test__labels_to_flavor_unrecognised_label():
             ("large", "x64"): "x64-large",
         },
         default_flavor="large",
-        ignore_labels={"self-hosted", "linux"},
     )
     labels = {"self-hosted", "linux", "arm64", "large", "noble"}
     with pytest.raises(_InvalidLabelCombinationError) as exc_info:
         _labels_to_flavor(labels, routing_table)
     assert "Invalid label combination:" in str(exc_info.value)
-
-
-def test__labels_to_flavor_ignore_labels():
-    """
-    arrange: Two flavors and a labels to flavor routing_table
-    act: Call labels_to_flavor with an ignored label.
-    assert: The correct flavor is returned.
-    """
-    routing_table = RoutingTable(
-        value={
-            ("arm64",): "large",
-            ("large",): "large",
-            ("arm64", "large"): "large",
-            ("x64",): "large-x64",
-            ("large", "x64"): "x64-large",
-        },
-        default_flavor="large",
-        ignore_labels={"self-hosted", "linux"},
-    )
-    labels = {"self-hosted", "linux", "arm64", "large"}
-    assert _labels_to_flavor(labels, routing_table) == "large"

--- a/webhook_router/app.py
+++ b/webhook_router/app.py
@@ -52,9 +52,7 @@ def config_app(flask_app: Flask) -> None:
     flask_app.config["DEFAULT_SELF_HOSTED_LABELS"] = default_self_hosted_labels
     flavor_labels_mapping_list = [tuple(item.items())[0] for item in flavors_config.flavor_list]
     flask_app.config["ROUTING_TABLE"] = to_routing_table(
-        flavor_label_mapping_list=flavor_labels_mapping_list,
-        ignore_labels=default_self_hosted_labels,
-        default_flavor=default_flavor,
+        flavor_label_mapping_list=flavor_labels_mapping_list, default_flavor=default_flavor
     )
 
 

--- a/webhook_router/app.py
+++ b/webhook_router/app.py
@@ -240,7 +240,7 @@ def _parse_job() -> Job:
     """
     payload = request.get_json()
     app.logger.debug("Received payload: %s", payload)
-    return webhook_to_job(webhook=payload, ignore_labels=app.config["DEFAULT_SELF_HOSTED_LABELS"])
+    return webhook_to_job(payload=payload, ignore_labels=app.config["DEFAULT_SELF_HOSTED_LABELS"])
 
 
 # Exclude from coverage since unit tests should not run as __main__

--- a/webhook_router/app.py
+++ b/webhook_router/app.py
@@ -49,6 +49,7 @@ def config_app(flask_app: Flask) -> None:
     default_self_hosted_labels = _parse_default_self_hosted_labels_config(
         flask_app.config.get("DEFAULT_SELF_HOSTED_LABELS", "")
     )
+    flask_app.config["DEFAULT_SELF_HOSTED_LABELS"] = default_self_hosted_labels
     flavor_labels_mapping_list = [tuple(item.items())[0] for item in flavors_config.flavor_list]
     flask_app.config["ROUTING_TABLE"] = to_routing_table(
         flavor_label_mapping_list=flavor_labels_mapping_list,
@@ -241,7 +242,7 @@ def _parse_job() -> Job:
     """
     payload = request.get_json()
     app.logger.debug("Received payload: %s", payload)
-    return webhook_to_job(payload)
+    return webhook_to_job(webhook=payload, ignore_labels=app.config["DEFAULT_SELF_HOSTED_LABELS"])
 
 
 # Exclude from coverage since unit tests should not run as __main__

--- a/webhook_router/parse.py
+++ b/webhook_router/parse.py
@@ -49,11 +49,11 @@ class Job(BaseModel):
     url: HttpUrl
 
 
-def webhook_to_job(webhook: dict, ignore_labels: Collection[str]) -> Job:
+def webhook_to_job(payload: dict, ignore_labels: Collection[str]) -> Job:
     """Parse a raw json payload and extract the required information.
 
     Args:
-        webhook: The webhook in json to parse.
+        payload: The webhook's payload in json to parse.
         ignore_labels: The labels to ignore when parsing. For example, "self-hosted" or "linux".
 
     Returns:
@@ -62,29 +62,29 @@ def webhook_to_job(webhook: dict, ignore_labels: Collection[str]) -> Job:
     Raises:
         ParseError: An error occurred during parsing.
     """
-    validation_result = _validate_webhook(webhook)
+    validation_result = _validate_webhook(payload)
     if not validation_result.is_valid:
         raise ParseError(f"Could not parse webhook: {validation_result.msg}")
 
     #  The enclosed code will be removed when compiling to optimised byte code.
 
-    assert "action" in webhook, f"action key not found in {webhook}"  # nosec
-    assert "workflow_job" in webhook, f"workflow_job key not found in {webhook}"  # nosec
+    assert "action" in payload, f"action key not found in {payload}"  # nosec
+    assert "workflow_job" in payload, f"workflow_job key not found in {payload}"  # nosec
     assert (  # nosec
-        "labels" in webhook["workflow_job"]
-    ), f"labels key not found in {webhook['workflow_job']}"
+        "labels" in payload["workflow_job"]
+    ), f"labels key not found in {payload['workflow_job']}"
     assert (  # nosec
-        "url" in webhook["workflow_job"]
-    ), f"url key not found in {webhook['workflow_job']}"
+        "url" in payload["workflow_job"]
+    ), f"url key not found in {payload['workflow_job']}"
 
-    status = webhook["action"]
-    workflow_job = webhook["workflow_job"]
+    status = payload["action"]
+    workflow_job = payload["workflow_job"]
 
     labels = workflow_job["labels"]
 
     if labels is None:
         raise ParseError(
-            f"Failed to create Webhook object for webhook {webhook}: Labels are missing"
+            f"Failed to create Webhook object for webhook {payload}: Labels are missing"
         )
 
     job_url = workflow_job["url"]
@@ -96,7 +96,7 @@ def webhook_to_job(webhook: dict, ignore_labels: Collection[str]) -> Job:
             url=job_url,
         )
     except ValueError as exc:
-        raise ParseError(f"Failed to create Webhook object for webhook {webhook}: {exc}") from exc
+        raise ParseError(f"Failed to create Webhook object for webhook {payload}: {exc}") from exc
 
 
 def _validate_webhook(webhook: dict) -> ValidationResult:

--- a/webhook_router/parse.py
+++ b/webhook_router/parse.py
@@ -143,7 +143,7 @@ def _validate_missing_keys(webhook: dict) -> ValidationResult:
 
 
 def _parse_labels(labels: Collection[str], ignore_labels: Collection[str]) -> Labels:
-    """Parse the raw labels and remove the ignore labels.
+    """Parse the labels coming from the payload and remove the ignore labels.
 
     Args:
         labels: The labels to parse from the payload.

--- a/webhook_router/router.py
+++ b/webhook_router/router.py
@@ -26,12 +26,10 @@ class RoutingTable(BaseModel):
 
     Attributes:
         value: The mapping of labels to flavors.
-        ignore_labels: The labels to ignore (e.g. "self-hosted" or "linux").
         default_flavor: The default flavor.
     """
 
     value: dict[LabelCombinationIdentifier, Label]
-    ignore_labels: set[Label]
     default_flavor: Flavor
 
 
@@ -39,15 +37,12 @@ FlavorLabelsMappingList = list[tuple[Flavor, list[Label]]]
 
 
 def to_routing_table(
-    flavor_label_mapping_list: FlavorLabelsMappingList,
-    ignore_labels: set[Label],
-    default_flavor: Flavor,
+    flavor_label_mapping_list: FlavorLabelsMappingList, default_flavor: Flavor
 ) -> RoutingTable:
     """Convert the flavor label mapping to a route table.
 
     Args:
         flavor_label_mapping_list: The list of mappings of flavors to labels.
-        ignore_labels: The labels to ignore (e.g. "self-hosted" or "linux").
         default_flavor: The default flavor to use if no labels are provided.
 
     Returns:
@@ -90,7 +85,6 @@ def to_routing_table(
     return RoutingTable(
         default_flavor=default_flavor,
         value=routing_table,
-        ignore_labels={label.lower() for label in ignore_labels},
     )
 
 
@@ -147,11 +141,10 @@ def _labels_to_flavor(labels: set[str], routing_table: RoutingTable) -> Flavor:
         The flavor.
     """
     labels_lowered = {label.lower() for label in labels}
-    final_labels = labels_lowered - routing_table.ignore_labels
-    if not final_labels:
+    if not labels_lowered:
         return routing_table.default_flavor
 
-    label_key = tuple(sorted(final_labels))
+    label_key = tuple(sorted(labels_lowered))
     if label_key not in routing_table.value:
         raise _InvalidLabelCombinationError(f"Invalid label combination: {labels}")
     return routing_table.value[label_key]


### PR DESCRIPTION
Applicable spec: [ISD-116](https://discourse.charmhub.io/t/specification-isd116-github-self-hosted-runners-reactive-scheduling/13755)

### Overview

Do not forward the default self-hosted labels.

### Rationale

These labels should be ignored, they have no effect on routing decisions. They are currently forwarded and must be ignored again by the consumer side.

### Juju Events Changes

n/a

### Module Changes

`parse.py`: Remove ignored labels from webhooks.
`router.py`: Remove ignore labels from routing table, as they are already removed during parsing.

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->


[ISD-116]: https://warthogs.atlassian.net/browse/ISD-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ