### PR TITLE
feat: use structured log for job_forwarded

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,5 +2,6 @@
 CVE-2024-34156
 # Vulnerability in golang.org/x/crypto introduced by statsd-exporter. We have to wait until it is fixed upstream: https://github.com/prometheus/statsd_exporter/blob/master/go.mod
 CVE-2024-45337
+CVE-2025-22869
 # Vulnerability in golang.org/x/net introduced by statsd-exporter. We have to wait until it is fixed upstream: https://github.com/prometheus/statsd_exporter/blob/master/go.mod
 CVE-2024-45338

--- a/src-docs/router.py.md
+++ b/src-docs/router.py.md
@@ -8,7 +8,7 @@ Module for routing webhooks to the appropriate message queue.
 
 ---
 
-<a href="../webhook_router/router.py#L39"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/router.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `to_routing_table`
 
@@ -36,7 +36,7 @@ Convert the flavor label mapping to a route table.
 
 ---
 
-<a href="../webhook_router/router.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/router.py#L92"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `forward`
 
@@ -62,7 +62,7 @@ Forward the job to the appropriate message queue.
 
 ---
 
-<a href="../webhook_router/router.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../webhook_router/router.py#L127"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `can_forward`
 

--- a/webhook_router/router.py
+++ b/webhook_router/router.py
@@ -2,6 +2,7 @@
 #  See LICENSE file for licensing details.
 """Module for routing webhooks to the appropriate message queue."""
 import itertools
+import json
 import logging
 
 from pydantic import BaseModel
@@ -110,7 +111,16 @@ def forward(job: Job, routing_table: RoutingTable) -> None:
     except _InvalidLabelCombinationError as e:
         raise RouterError(f"Not able to forward job: {e}") from e
 
-    logger.info("Received job %s for flavor %s", job.json(), flavor)
+    logger.info(
+        json.dumps(
+            {
+                "log_type": "job_forwarded",
+                "labels": [label for label in job.labels],
+                "url": job.url,
+                "flavor": flavor,
+            }
+        )
+    )
     mq.add_job_to_queue(job, flavor)
 
 

--- a/webhook_router/router.py
+++ b/webhook_router/router.py
@@ -115,8 +115,8 @@ def forward(job: Job, routing_table: RoutingTable) -> None:
         json.dumps(
             {
                 "log_type": "job_forwarded",
-                "labels": [label for label in job.labels],
-                "url": job.url,
+                "labels": list(job.labels),
+                "url": str(job.url),
                 "flavor": flavor,
             }
         )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Use a structured json log for the job forwarding log message.


### Rationale

This eases querying and visualizing the number of jobs forwarded in Loki/Grafana. Use a structured JSON log for the job forward log message.



<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
