### PR TITLE
print stack trace of invalid action params

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -9,3 +9,5 @@ CVE-2024-45338
 CVE-2025-22874
 # Vulnerability in golang.org/x/oauth2/jws introduced by statsd-exporter.
 CVE-2025-22868
+# Vulnerability in go stdlib introduced by statsd-exporter.
+CVE-2025-47907

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -70,6 +70,7 @@ class FlaskCharm(paas_charm.flask.Charm):
         try:
             auth_env = self._get_github_auth_env(event)
         except _ActionParamsInvalidError as exc:
+            logger.exception("Invalid action parameters passed, %s", exc)
             event.fail(f"Invalid action parameters passed: {exc}")
             return
         try:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Print stack trace of invalid action params

### Rationale

to deeper understand why certain action params are invalid. Concrete use case: Accessing a secret is not possible, and the event message doesn't contain the root cause, which the underlying exception might have. 

### Juju Events Changes

Change to action handler.

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
