### PR TITLE
Force ingress publish data on charm init

### DIFF
--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -49,6 +49,12 @@ class FlaskCharm(paas_charm.flask.Charm):
         self.framework.observe(
             self.on.redeliver_failed_webhooks_action, self._on_redeliver_failed_webhooks_action
         )
+        # Sometimes the ingress library doesn't properly handle pod
+        # restarts,which can cause the IP field inside the ingress
+        # relation data to become stale, resulting in ingress failures.
+        # As a workaround, force refresh the ingress relation data
+        # (especially the ip field) on every event.
+        self._ingress._publish_auto_data()
 
     def get_cos_dir(self) -> str:
         """Return the directory with COS related files.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Sometimes the ingress library doesn't properly handle pod
restarts,which can cause the IP field inside the ingress
relation data to become stale, resulting in ingress failures.
As a workaround, force refresh the ingress relation data (especially the ip field) on every event.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
